### PR TITLE
delete unnecessary test.cpp file

### DIFF
--- a/build/activity-tracker.vcxproj
+++ b/build/activity-tracker.vcxproj
@@ -195,7 +195,6 @@
     <ClCompile Include="..\libs\jsoncpp-1.7.7\jsoncpp.cpp" />
     <ClCompile Include="..\src\aps_meter.cpp" />
     <ClCompile Include="..\src\logger\logger.cpp" />
-    <ClCompile Include="..\src\logger\test.cpp" />
     <ClCompile Include="..\src\tracker.cpp" />
     <ClCompile Include="..\src\utils.cpp" />
     <ClCompile Include="..\src\utils_win.cpp" />

--- a/build/activity-tracker.vcxproj.filters
+++ b/build/activity-tracker.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="libs">
@@ -45,9 +45,6 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\logger\logger.cpp">
-      <Filter>src\logger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\logger\test.cpp">
       <Filter>src\logger</Filter>
     </ClCompile>
     <ClCompile Include="..\src\tracker.cpp">

--- a/build/activity-tracker.vcxproj.filters
+++ b/build/activity-tracker.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="libs">


### PR DESCRIPTION
visual studio 2015 에서 test.cpp 파일을 찾을 수 없다며 에러 발생합니다.